### PR TITLE
Fix defaultConfig path for variables

### DIFF
--- a/template/RELEASE_NOTES.md
+++ b/template/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 
 ## 0.5.0-alpha
 ##### Template
+* Fix defaultConfig path for variables
 * Fix uploadCrashlyticsMappingFileQa task Failed
 * Fix bug in DebugCatalogItemLayout
 * Add chucker

--- a/template/app/build.gradle
+++ b/template/app/build.gradle
@@ -17,10 +17,10 @@ apply from: '../androidTestConfiguration.gradle'
 android {
 
     defaultConfig {
-        applicationId meta.applicationId
+        applicationId app.applicationId
 
-        versionCode meta.versionCode
-        versionName meta.versionName
+        versionCode app.versionCode
+        versionName app.versionName
 
         //setProperty("archivesBaseName", "$applicationName-$versionName-($versionCode)") //todo uncomment for real app
 


### PR DESCRIPTION
Поправил пути для переменных, а то при формировании сборки, получалось такое название файла:
![image](https://user-images.githubusercontent.com/28761889/147084420-68c63bde-4a95-4353-9d2e-e00092c15075.png)
